### PR TITLE
docs: create `alerting` & `notification` base structures

### DIFF
--- a/alerting/docs/alerting.md
+++ b/alerting/docs/alerting.md
@@ -1,0 +1,43 @@
+# This file describes the alerting API
+
+## Alerting rule structure
+
+```rust
+struct AlertingRule {
+    name: String,
+    ruleType: RuleType,
+    metricName: String,
+    threshold: f64,
+    trigger: Trigger,
+    duration: u64,
+    notificationChannelIds: Vec<String>,
+}
+
+enum RuleType {
+    ValueBased,
+    PriceBased,
+}
+
+enum Trigger {
+    GreaterThan,
+    LessThan,
+    Equal,
+    NotEqual,
+}
+```
+
+## Alerts structure
+
+```rust
+struct Alert {
+    alertingRuleId: String,
+    value: f64,
+    status: Status,
+    notificationId: String,
+}
+
+enum Status {
+    Triggered(u64), // timestamp
+    Resolved(u64), // timestamp
+}
+```

--- a/notification/docs/notification.md
+++ b/notification/docs/notification.md
@@ -1,0 +1,32 @@
+# This file describes the notification API
+
+## Notification channel configuration
+
+```rust
+struct NotificationChannel {
+    name: String,
+    channelType: ChannelType,
+    recipient: String, // email, phone number, webhook url, etc.
+}
+
+enum ChannelType {
+    Email,
+    Slack,
+    Webhook,
+    Phone,
+}
+```
+
+## Notification structure
+
+```rust
+struct Notification {
+    notificationChannelId: String,
+    status: Status,
+}
+
+enum Status {
+    Sent(u64), // timestamp
+    Failed(u64), // timestamp
+}
+```


### PR DESCRIPTION
Created the base structures that will guide the full workflow between the `alerting` and `notification` services