### PR TITLE
fix: switch to async_channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-graphql"
 version = "5.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,11 +448,20 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-trait",
  "chrono",
- "crossbeam-channel",
  "sqlx",
  "thiserror",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.68"
-crossbeam-channel = "0.5.1"
+async-channel = "1.8.0"
 thiserror = "1.0.40"
 chrono = "0.4.26"
 anyhow = "1.0.71"

--- a/common/src/messaging/crossbeam/mod.rs
+++ b/common/src/messaging/crossbeam/mod.rs
@@ -12,70 +12,72 @@ use thiserror::Error;
 use super::{AsyncReceiver, AsyncSender};
 
 #[derive(Error, Debug)]
-pub enum CrossbeamSenderError {
+pub enum AsyncChannelSenderError {
     #[error("Channel disconnected")]
     ChannelDisconnected,
 }
 
 #[derive(Error, Debug)]
-pub enum CrossbeamReceiverError {
+pub enum AsyncChannelReceiverError {
     #[error("ReceiveError {0}")]
-    ReceiveError(crossbeam_channel::RecvError),
+    ReceiveError(async_channel::RecvError),
 }
 
 #[derive(Clone)]
 pub struct CrossbeamReceiver<T: Send> {
-    receiver: crossbeam_channel::Receiver<T>,
+    receiver: async_channel::Receiver<T>,
 }
 
 #[derive(Clone)]
 pub struct CrossbeamSender<T: Send> {
-    sender: crossbeam_channel::Sender<T>,
+    sender: async_channel::Sender<T>,
 }
 
 impl<T: Send> CrossbeamReceiver<T> {
-    pub fn new(receiver: crossbeam_channel::Receiver<T>) -> Self {
+    pub fn new(receiver: async_channel::Receiver<T>) -> Self {
         Self { receiver }
     }
 }
 
 #[async_trait]
-impl<T: Send> AsyncReceiver<T, CrossbeamReceiverError> for CrossbeamReceiver<T> {
-    async fn receive(&mut self) -> Result<T, CrossbeamReceiverError> {
+impl<T: Send> AsyncReceiver<T, AsyncChannelReceiverError> for CrossbeamReceiver<T> {
+    async fn receive(&mut self) -> Result<T, AsyncChannelReceiverError> {
         self.receiver
             .recv()
-            .map_err(CrossbeamReceiverError::ReceiveError)
+            .await
+            .map_err(AsyncChannelReceiverError::ReceiveError)
     }
 }
 
 impl<T: Send> CrossbeamSender<T> {
-    pub fn new(sender: crossbeam_channel::Sender<T>) -> Self {
+    pub fn new(sender: async_channel::Sender<T>) -> Self {
         Self { sender }
     }
 }
 
 #[async_trait]
-impl<T: Send> AsyncSender<T, CrossbeamSenderError> for CrossbeamSender<T> {
-    async fn send(&mut self, message: T) -> Result<(), CrossbeamSenderError> {
+impl<T: Send> AsyncSender<T, AsyncChannelSenderError> for CrossbeamSender<T> {
+    async fn send(&mut self, message: T) -> Result<(), AsyncChannelSenderError> {
         self.sender
             .send(message)
-            .map_err(|_| CrossbeamSenderError::ChannelDisconnected)
+            .await
+            .map_err(|_| AsyncChannelSenderError::ChannelDisconnected)
     }
 }
 
 pub struct CrossbeamMessagingFactory {
-    billable_sender: crossbeam_channel::Sender<crate::models::Billable>,
-    billable_receiver: crossbeam_channel::Receiver<crate::models::Billable>,
-    metric_sender: crossbeam_channel::Sender<crate::models::Metric>,
-    metric_receiver: crossbeam_channel::Receiver<crate::models::Metric>,
+    billable_sender: async_channel::Sender<crate::models::Billable>,
+    billable_receiver: async_channel::Receiver<crate::models::Billable>,
+    metric_sender: async_channel::Sender<crate::models::Metric>,
+    metric_receiver: async_channel::Receiver<crate::models::Metric>,
 }
 
 impl CrossbeamMessagingFactory {}
 
 impl Default for CrossbeamMessagingFactory {
     fn default() -> Self {
-        let (billable_sender, billable_receiver) = crossbeam_channel::unbounded();
-        let (metric_sender, metric_receiver) = crossbeam_channel::unbounded();
+        let (billable_sender, billable_receiver) = async_channel::unbounded();
+        let (metric_sender, metric_receiver) = async_channel::unbounded();
 
         Self {
             billable_sender,


### PR DESCRIPTION
Async_channel provides virtually the same API as crossbeam_channel, but its underlying implementation plays nicely with tokio runtime, yielding on recv for example.