### PR TITLE
fix(ci): clean

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt
 
+      - name: Clean
+        run: cargo clean -p ${{ matrix.component }}
+
       - name: Build
         run: cargo build -p ${{ matrix.component }}
 


### PR DESCRIPTION
Some builds are failing during `cargo build` saying : `could not find `join` in `tokio`

Added a `clean` task to clear cache to be sure we are in a clean environment